### PR TITLE
HW3 (SOLID & GRASP)

### DIFF
--- a/src/subscription/application/notification/dto/confirmation-email.dto.ts
+++ b/src/subscription/application/notification/dto/confirmation-email.dto.ts
@@ -1,0 +1,4 @@
+export interface ConfirmationEmailDto {
+  email: string;
+  token: string;
+}

--- a/src/subscription/application/notification/dto/subscription-confirmed-email.dto.ts
+++ b/src/subscription/application/notification/dto/subscription-confirmed-email.dto.ts
@@ -1,0 +1,9 @@
+import { SubscriptionFrequencyEnum } from 'src/common/enums/subscription-frequency.enum';
+import { Weather } from 'src/weather/domain/weather.model';
+
+export interface SubscriptionConfirmedEmailDto {
+  frequency: SubscriptionFrequencyEnum;
+  city: string;
+  weather: Weather;
+  token: string;
+}

--- a/src/subscription/application/notification/dto/weather-update-email.dto.ts
+++ b/src/subscription/application/notification/dto/weather-update-email.dto.ts
@@ -1,0 +1,8 @@
+import { Weather } from 'src/weather/domain/weather.model';
+
+export interface WeatherUpdateEmailDto {
+  email: string;
+  city: string;
+  weather: Weather;
+  token: string;
+}

--- a/src/subscription/application/notification/subscription-email-link.helper.ts
+++ b/src/subscription/application/notification/subscription-email-link.helper.ts
@@ -1,13 +1,12 @@
+const domain = process.env.APP_DOMAIN ?? 'localhost';
+const port = process.env.APP_PORT ?? '3000';
+
 export class SubscriptionEmailLinkHelper {
-  static getConfirmLink(domain: string, port: string, token: string): string {
+  static getConfirmLink(token: string): string {
     return `http://${domain}:${port}/subscription/confirm/${token}`;
   }
 
-  static getUnsubscribeLink(
-    domain: string,
-    port: string,
-    token: string,
-  ): string {
+  static getUnsubscribeLink(token: string): string {
     return `http://${domain}:${port}/subscription/unsubscribe/${token}`;
   }
 }

--- a/src/subscription/application/notification/subscription-email-link.helper.ts
+++ b/src/subscription/application/notification/subscription-email-link.helper.ts
@@ -1,0 +1,13 @@
+export class SubscriptionEmailLinkHelper {
+  static getConfirmLink(domain: string, port: string, token: string): string {
+    return `http://${domain}:${port}/subscription/confirm/${token}`;
+  }
+
+  static getUnsubscribeLink(
+    domain: string,
+    port: string,
+    token: string,
+  ): string {
+    return `http://${domain}:${port}/subscription/unsubscribe/${token}`;
+  }
+}

--- a/src/subscription/application/notification/subscription-notification.service.ts
+++ b/src/subscription/application/notification/subscription-notification.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { MailService } from 'src/mail/application/mail.service';
+import { MailTemplates } from 'src/mail/constants/mail.templates';
+import { Weather } from 'src/weather/domain/weather.model';
+import { SubscriptionEmailLinkHelper } from './subscription-email-link.helper';
+import { SubscriptionFrequencyEnum } from 'src/common/enums/subscription-frequency.enum';
+
+@Injectable()
+export class SubscriptionNotificationService {
+  constructor(private readonly mailService: MailService) {}
+
+  async sendConfirmationEmail(
+    email: string,
+    token: string,
+    domain: string,
+    port: string,
+  ): Promise<void> {
+    const confirmLink = SubscriptionEmailLinkHelper.getConfirmLink(
+      domain,
+      port,
+      token,
+    );
+
+    await this.mailService.sendMail({
+      receiverEmail: email,
+      subject: MailTemplates.CONFIRM_SUBSCRIPTION.subject,
+      html: MailTemplates.CONFIRM_SUBSCRIPTION.html(confirmLink, token),
+    });
+  }
+
+  async sendUnsubscribeSuccess(email: string): Promise<void> {
+    await this.mailService.sendMail({
+      receiverEmail: email,
+      subject: MailTemplates.UNSUBSCRIBE_SUCCESS.subject,
+      html: MailTemplates.UNSUBSCRIBE_SUCCESS.html(),
+    });
+  }
+
+  async sendSubscriptionConfirmedEmail(
+    email: string,
+    frequency: SubscriptionFrequencyEnum,
+    city: string,
+    weather: Weather,
+    token: string,
+    domain: string,
+    port: string,
+  ): Promise<void> {
+    const unsubscribeLink = SubscriptionEmailLinkHelper.getUnsubscribeLink(
+      domain,
+      port,
+      token,
+    );
+
+    await this.mailService.sendMail({
+      receiverEmail: email,
+      subject: MailTemplates.SUBSCRIPTION_CONFIRMED.subject,
+      html: MailTemplates.SUBSCRIPTION_CONFIRMED.html(
+        frequency,
+        city,
+        weather,
+        unsubscribeLink,
+      ),
+    });
+  }
+
+  async sendWeatherUpdate(
+    email: string,
+    city: string,
+    weather: Weather,
+    token: string,
+    domain: string,
+    port: string,
+  ): Promise<void> {
+    const unsubscribeLink = SubscriptionEmailLinkHelper.getUnsubscribeLink(
+      domain,
+      port,
+      token,
+    );
+
+    await this.mailService.sendMail({
+      receiverEmail: email,
+      subject: MailTemplates.WEATHER_UPDATE.subject(city),
+      html: MailTemplates.WEATHER_UPDATE.html(city, weather, unsubscribeLink),
+    });
+  }
+}

--- a/src/subscription/application/subscription.service.ts
+++ b/src/subscription/application/subscription.service.ts
@@ -2,14 +2,13 @@ import { Injectable, Inject } from '@nestjs/common';
 import { CreateSubscriptionDto } from '../dtos/create-subscription.dto';
 import { Subscription } from '../domain/subscription.model';
 import { SubscriptionRepository } from '../domain/subscription.repository.interface';
-import { MailService } from 'src/mail/application/mail.service';
 import { WeatherService } from 'src/weather/application/weather.service';
 import { Weather } from 'src/weather/domain/weather.model';
 import { TokenService } from 'src/token/application/token.service';
 import { SubscriptionFrequencyEnum } from 'src/common/enums/subscription-frequency.enum';
 import { SubscriptionErrorCode } from '../constants/subscription.errors';
 import { ConfigService } from '@nestjs/config';
-import { MailTemplates } from 'src/mail/constants/mail.templates';
+import { SubscriptionNotificationService } from './notification/subscription-notification.service';
 
 @Injectable()
 export class SubscriptionService {
@@ -20,8 +19,8 @@ export class SubscriptionService {
     @Inject('SubscriptionRepository')
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly tokenService: TokenService,
-    private readonly mailService: MailService,
     private readonly weatherService: WeatherService,
+    private readonly notificationService: SubscriptionNotificationService,
     private readonly configService: ConfigService,
   ) {
     this.appPort = this.configService.get<string>('APP_PORT') ?? '3000';
@@ -49,7 +48,13 @@ export class SubscriptionService {
       tokenId: token.id,
     });
 
-    await this.sendConfirmationEmail(subscription.email, token.value);
+    await this.notificationService.sendConfirmationEmail(
+      subscription.email,
+      token.value,
+      this.appDomain,
+      this.appPort,
+    );
+
     return subscription;
   }
 
@@ -71,21 +76,19 @@ export class SubscriptionService {
       )) as Subscription;
     }
 
-    const unsubscribeLink = `http://${this.appDomain}:${this.appPort}/subscription/unsubscribe/${token.value}`;
     const weather = await this.weatherService.getCurrentWeather(
       subscription.city,
     );
 
-    await this.mailService.sendMail({
-      receiverEmail: subscription.email,
-      subject: MailTemplates.SUBSCRIPTION_CONFIRMED.subject,
-      html: MailTemplates.SUBSCRIPTION_CONFIRMED.html(
-        subscription.frequency,
-        subscription.city,
-        weather,
-        unsubscribeLink,
-      ),
-    });
+    await this.notificationService.sendSubscriptionConfirmedEmail(
+      subscription.email,
+      subscription.frequency,
+      subscription.city,
+      weather,
+      token.value,
+      this.appDomain,
+      this.appPort,
+    );
 
     return subscription;
   }
@@ -104,24 +107,8 @@ export class SubscriptionService {
     const subscription = subscriptions[0];
     await this.subscriptionRepository.remove(subscription.id);
     await this.tokenService.remove(token.id);
-    await this.mailService.sendMail({
-      receiverEmail: subscription.email,
-      subject: MailTemplates.UNSUBSCRIBE_SUCCESS.subject,
-      html: MailTemplates.UNSUBSCRIBE_SUCCESS.html(),
-    });
-  }
 
-  private async sendConfirmationEmail(
-    email: string,
-    token: string,
-  ): Promise<void> {
-    const confirmLink = `http://${this.appDomain}:${this.appPort}/subscription/confirm/${token}`;
-
-    await this.mailService.sendMail({
-      receiverEmail: email,
-      subject: MailTemplates.CONFIRM_SUBSCRIPTION.subject,
-      html: MailTemplates.CONFIRM_SUBSCRIPTION.html(confirmLink, token),
-    });
+    await this.notificationService.sendUnsubscribeSuccess(subscription.email);
   }
 
   async getConfirmedSubscriptionsByFrequency(
@@ -149,17 +136,15 @@ export class SubscriptionService {
         }
 
         const token = await this.tokenService.findById(sub.tokenId);
-        const unsubscribeLink = `http://${this.appDomain}:${this.appPort}/subscription/unsubscribe/${token.value}`;
 
-        await this.mailService.sendMail({
-          receiverEmail: sub.email,
-          subject: MailTemplates.WEATHER_UPDATE.subject(sub.city),
-          html: MailTemplates.WEATHER_UPDATE.html(
-            sub.city,
-            weather,
-            unsubscribeLink,
-          ),
-        });
+        await this.notificationService.sendWeatherUpdate(
+          sub.email,
+          sub.city,
+          weather,
+          token.value,
+          this.appDomain,
+          this.appPort,
+        );
       } catch (err) {
         console.error(`Failed to send weather to ${sub.email}:`, err);
       }

--- a/src/subscription/subscription.module.ts
+++ b/src/subscription/subscription.module.ts
@@ -10,6 +10,7 @@ import { WeatherModule } from 'src/weather/weather.module';
 import { SubscriptionCronService } from './application/cron/subscription.cron';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TokenModule } from 'src/token/token.module';
+import { SubscriptionNotificationService } from './application/notification/subscription-notification.service';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { TokenModule } from 'src/token/token.module';
   providers: [
     SubscriptionService,
     SubscriptionCronService,
+    SubscriptionNotificationService,
     {
       provide: 'SubscriptionRepository',
       useClass: TypeOrmSubscriptionRepository,


### PR DESCRIPTION
Previously, SubscriptionService violated the **Single Responsibility Principle** and had **low cohesion** according to GRASP. It handled both business logic and notification logic, including email templates and link formatting. These responsibilities were not aligned with its core purpose.

This pull request refactors the SubscriptionService by moving all responsibilities related to sending emails and building confirmation/unsubscribe links into a new SubscriptionNotificationService. It also introduces a helper class, SubscriptionEmailLinkHelper, for generating URLs.

Now, SubscriptionService is focused only on managing subscriptions, while all notification-related concerns are delegated.