### PR TITLE
HW5 (GoF patterns)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 WEATHER_API_KEY=your_weather_api_key_here
 WEATHER_API_BASE_URL=http://api.weatherapi.com/v1/current.json
 
+OPENWEATHER_API_KEY=your_open_weather_map_api_key_here
+OPENWEATHER_API_BASE_URL=https://api.openweathermap.org/data/2.5/weather
+
 POSTGRES_HOST=your_postgres_host
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres

--- a/src/config/app-config.service.ts
+++ b/src/config/app-config.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { MailerOptions } from '@nestjs-modules/mailer';
+import { WeatherProviderConfig } from 'src/weather/domain/types/weather-provider-config.type';
 
 @Injectable()
 export class AppConfigService {
@@ -20,7 +21,7 @@ export class AppConfigService {
     };
   }
 
-  getWeatherApiConfig() {
+  getWeatherApiConfig(): WeatherProviderConfig {
     const baseUrl = process.env.WEATHER_API_BASE_URL;
     const apiKey = process.env.WEATHER_API_KEY;
 
@@ -33,7 +34,7 @@ export class AppConfigService {
     return { baseUrl, apiKey };
   }
 
-  getOpenWeatherMapConfig() {
+  getOpenWeatherMapConfig(): WeatherProviderConfig {
     const baseUrl = process.env.OPENWEATHER_API_BASE_URL;
     const apiKey = process.env.OPENWEATHER_API_KEY;
 

--- a/src/config/app-config.service.ts
+++ b/src/config/app-config.service.ts
@@ -33,6 +33,19 @@ export class AppConfigService {
     return { baseUrl, apiKey };
   }
 
+  getOpenWeatherMapConfig() {
+    const baseUrl = process.env.OPENWEATHER_API_BASE_URL;
+    const apiKey = process.env.OPENWEATHER_API_KEY;
+
+    if (!baseUrl || !apiKey) {
+      throw new Error(
+        'Missing OPENWEATHER_API_BASE_URL or OPENWEATHER_API_KEY in environment',
+      );
+    }
+
+    return { baseUrl, apiKey };
+  }
+
   getMailerConfig(): MailerOptions {
     return {
       transport: {

--- a/src/weather/application/weather-client.ts
+++ b/src/weather/application/weather-client.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { WeatherProvider } from '../domain/interfaces/weather-provider.interface';
+import { WeatherData } from '../domain/types/weather-data.type';
+
+@Injectable()
+export class WeatherClient {
+  constructor(private readonly providers: WeatherProvider[]) {}
+
+  async getWeather(city: string): Promise<WeatherData> {
+    console.log(this.providers);
+    for (const provider of this.providers) {
+      try {
+        return provider.getWeather(city);
+      } catch (error) {
+        console.log(error);
+        continue;
+      }
+    }
+
+    throw new Error('All weather providers failed');
+  }
+}

--- a/src/weather/application/weather-client.ts
+++ b/src/weather/application/weather-client.ts
@@ -1,22 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { WeatherProvider } from '../domain/interfaces/weather-provider.interface';
 import { WeatherData } from '../domain/types/weather-data.type';
+import { WeatherProviderChain } from './weather-provider-chain';
 
 @Injectable()
 export class WeatherClient {
-  constructor(private readonly providers: WeatherProvider[]) {}
+  private readonly chain: WeatherProviderChain;
 
-  async getWeather(city: string): Promise<WeatherData> {
-    console.log(this.providers);
-    for (const provider of this.providers) {
-      try {
-        return provider.getWeather(city);
-      } catch (error) {
-        console.log(error);
-        continue;
-      }
-    }
+  constructor(providers: WeatherProvider[]) {
+    this.chain = new WeatherProviderChain(providers);
+  }
 
-    throw new Error('All weather providers failed');
+  getWeather(city: string): Promise<WeatherData> {
+    return this.chain.getWeather(city);
   }
 }

--- a/src/weather/application/weather-provider-chain.spec.ts
+++ b/src/weather/application/weather-provider-chain.spec.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { WeatherProviderChain } from './weather-provider-chain';
+import { WeatherProvider } from '../domain/interfaces/weather-provider.interface';
+import { WeatherData } from '../domain/types/weather-data.type';
+
+describe('WeatherProviderChain', () => {
+  const city = 'Kyiv';
+  const mockData: WeatherData = {
+    temperature: 25,
+    humidity: 60,
+    description: 'Sunny',
+  };
+
+  it('should return result from first successful provider', async () => {
+    const provider1: WeatherProvider = {
+      getWeather: jest.fn().mockResolvedValue(mockData),
+    };
+    const provider2: WeatherProvider = { getWeather: jest.fn() };
+
+    const chain = new WeatherProviderChain([provider1, provider2]);
+    const result = await chain.getWeather(city);
+
+    expect(result).toEqual(mockData);
+    expect(provider1.getWeather).toHaveBeenCalledWith(city);
+    expect(provider2.getWeather).not.toHaveBeenCalled();
+  });
+
+  it('should fallback to second provider if first fails', async () => {
+    const provider1: WeatherProvider = {
+      getWeather: jest.fn().mockRejectedValue(new Error('Fail')),
+    };
+    const provider2: WeatherProvider = {
+      getWeather: jest.fn().mockResolvedValue(mockData),
+    };
+
+    const chain = new WeatherProviderChain([provider1, provider2]);
+    const result = await chain.getWeather(city);
+
+    expect(result).toEqual(mockData);
+    expect(provider1.getWeather).toHaveBeenCalledWith(city);
+    expect(provider2.getWeather).toHaveBeenCalledWith(city);
+  });
+
+  it('should throw error if all providers fail', async () => {
+    const provider1: WeatherProvider = {
+      getWeather: jest.fn().mockRejectedValue(new Error('Fail 1')),
+    };
+    const provider2: WeatherProvider = {
+      getWeather: jest.fn().mockRejectedValue(new Error('Fail 2')),
+    };
+
+    const chain = new WeatherProviderChain([provider1, provider2]);
+    await expect(chain.getWeather(city)).rejects.toThrow(
+      'All weather providers failed',
+    );
+  });
+});

--- a/src/weather/application/weather-provider-chain.ts
+++ b/src/weather/application/weather-provider-chain.ts
@@ -1,0 +1,24 @@
+import { WeatherProvider } from '../domain/interfaces/weather-provider.interface';
+import { WeatherData } from '../domain/types/weather-data.type';
+
+export class WeatherProviderChain {
+  private index = 0;
+
+  constructor(private readonly providers: WeatherProvider[]) {}
+
+  async getWeather(city: string): Promise<WeatherData> {
+    if (this.index >= this.providers.length) {
+      throw new Error('All weather providers failed');
+    }
+
+    const provider = this.providers[this.index];
+    this.index++;
+
+    try {
+      return await provider.getWeather(city);
+    } catch (error) {
+      console.warn(`[Provider error]: ${error}`);
+      return this.getWeather(city);
+    }
+  }
+}

--- a/src/weather/application/weather-provider-chain.ts
+++ b/src/weather/application/weather-provider-chain.ts
@@ -2,23 +2,17 @@ import { WeatherProvider } from '../domain/interfaces/weather-provider.interface
 import { WeatherData } from '../domain/types/weather-data.type';
 
 export class WeatherProviderChain {
-  private index = 0;
-
   constructor(private readonly providers: WeatherProvider[]) {}
 
   async getWeather(city: string): Promise<WeatherData> {
-    if (this.index >= this.providers.length) {
-      throw new Error('All weather providers failed');
+    for (const provider of this.providers) {
+      try {
+        return await provider.getWeather(city);
+      } catch {
+        continue;
+      }
     }
 
-    const provider = this.providers[this.index];
-    this.index++;
-
-    try {
-      return await provider.getWeather(city);
-    } catch (error) {
-      console.warn(`[Provider error]: ${error}`);
-      return this.getWeather(city);
-    }
+    throw new Error('All weather providers failed');
   }
 }

--- a/src/weather/application/weather.service.spec.ts
+++ b/src/weather/application/weather.service.spec.ts
@@ -1,65 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { WeatherService } from './weather.service';
-import { HttpService } from '@nestjs/axios';
-import { AppConfigService } from 'src/config/app-config.service';
-import { of } from 'rxjs';
-import { AxiosHeaders, AxiosResponse } from 'axios';
+import { WeatherClient } from './weather-client';
 import { Weather } from '../domain/weather.model';
+import { WeatherData } from '../domain/types/weather-data.type';
 
 describe('WeatherService', () => {
   let service: WeatherService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let httpService: HttpService;
+  let client: WeatherClient;
 
-  const mockAppConfigService = {
-    getWeatherApiConfig: () => ({
-      baseUrl: 'http://weather-api.com',
-      apiKey: 'test-api-key',
-    }),
+  const mockWeatherData: WeatherData = {
+    temperature: 20,
+    humidity: 60,
+    description: 'Sunny',
   };
 
-  const mockHttpService = {
-    get: jest.fn(),
+  const mockWeatherClient = {
+    getWeather: jest.fn().mockResolvedValue(mockWeatherData),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         WeatherService,
-        { provide: HttpService, useValue: mockHttpService },
-        { provide: AppConfigService, useValue: mockAppConfigService },
+        { provide: WeatherClient, useValue: mockWeatherClient },
       ],
     }).compile();
 
     service = module.get<WeatherService>(WeatherService);
-    httpService = module.get<HttpService>(HttpService);
+    client = module.get<WeatherClient>(WeatherClient);
   });
 
   it('should return current weather for a city', async () => {
     const city = 'Kyiv';
-    const mockResponse: AxiosResponse = {
-      data: {
-        location: { name: 'Kyiv' },
-        current: {
-          temp_c: 20,
-          humidity: 60,
-          condition: { text: 'Sunny' },
-        },
-      },
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: {
-        headers: new AxiosHeaders(),
-      },
-    };
-
-    mockHttpService.get.mockReturnValue(of(mockResponse));
-
     const result = await service.getCurrentWeather(city);
+
     expect(result).toEqual(new Weather(20, 60, 'Sunny'));
-    expect(mockHttpService.get).toHaveBeenCalledWith(
-      'http://weather-api.com?key=test-api-key&q=Kyiv&aqi=no',
-    );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.getWeather).toHaveBeenCalledWith(city);
   });
 });

--- a/src/weather/application/weather.service.ts
+++ b/src/weather/application/weather.service.ts
@@ -1,38 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { Weather } from '../domain/weather.model';
-import { HttpService } from '@nestjs/axios';
-import { lastValueFrom } from 'rxjs';
-import { AxiosResponse } from 'axios';
-import { WeatherApiResponse } from '../../common/interfaces/weatherapi-response.interface';
-import { AppConfigService } from 'src/config/app-config.service';
+import { WeatherClient } from './weather-client';
 
 @Injectable()
 export class WeatherService {
-  private readonly baseUrl: string;
-  private readonly apiKey: string;
-
-  constructor(
-    private readonly httpService: HttpService,
-    appConfigService: AppConfigService,
-  ) {
-    const { baseUrl, apiKey } = appConfigService.getWeatherApiConfig();
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
+  constructor(private readonly client: WeatherClient) {}
 
   async getCurrentWeather(city: string): Promise<Weather> {
-    const url = `${this.baseUrl}?key=${this.apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
-
-    const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
-      this.httpService.get<WeatherApiResponse>(url),
-    );
-
-    const data = response.data;
-
-    return new Weather(
-      data.current.temp_c,
-      data.current.humidity,
-      data.current.condition.text,
-    );
+    const data = await this.client.getWeather(city);
+    return new Weather(data.temperature, data.humidity, data.description);
   }
 }

--- a/src/weather/domain/interfaces/weather-provider.interface.ts
+++ b/src/weather/domain/interfaces/weather-provider.interface.ts
@@ -1,0 +1,5 @@
+import { WeatherData } from '../types/weather-data.type';
+
+export interface WeatherProvider {
+  getWeather(city: string): Promise<WeatherData>;
+}

--- a/src/weather/domain/types/weather-data.type.ts
+++ b/src/weather/domain/types/weather-data.type.ts
@@ -1,0 +1,5 @@
+export type WeatherData = {
+  temperature: number;
+  humidity: number;
+  description: string;
+};

--- a/src/weather/domain/types/weather-provider-config.type.ts
+++ b/src/weather/domain/types/weather-provider-config.type.ts
@@ -1,0 +1,4 @@
+export type WeatherProviderConfig = {
+  baseUrl: string;
+  apiKey: string;
+};

--- a/src/weather/infrastructure/helpers/weather-url.builder.ts
+++ b/src/weather/infrastructure/helpers/weather-url.builder.ts
@@ -1,0 +1,15 @@
+export function buildOpenWeatherMapUrl(
+  baseUrl: string,
+  apiKey: string,
+  city: string,
+): string {
+  return `${baseUrl}?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric`;
+}
+
+export function buildWeatherApiUrl(
+  baseUrl: string,
+  apiKey: string,
+  city: string,
+): string {
+  return `${baseUrl}?key=${apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
+}

--- a/src/weather/infrastructure/logger/weather-logger.config.ts
+++ b/src/weather/infrastructure/logger/weather-logger.config.ts
@@ -1,0 +1,7 @@
+import * as path from 'path';
+
+export const WEATHER_LOG_FILE_PATH = path.resolve(
+  process.cwd(),
+  'logs',
+  'weather.log',
+);

--- a/src/weather/infrastructure/logger/weather.logger.spec.ts
+++ b/src/weather/infrastructure/logger/weather.logger.spec.ts
@@ -1,0 +1,49 @@
+import { WeatherLogger } from './weather.logger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+jest.mock('fs');
+
+describe('WeatherLogger', () => {
+  let logger: WeatherLogger;
+  let mockWriteStream: { write: jest.Mock; end: jest.Mock };
+
+  beforeEach(() => {
+    mockWriteStream = {
+      write: jest.fn(),
+      end: jest.fn(),
+    };
+
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.createWriteStream as jest.Mock).mockReturnValue(mockWriteStream);
+
+    logger = new WeatherLogger();
+  });
+
+  it('should write formatted log message', () => {
+    const provider = 'test-provider';
+    const message = 'test log';
+
+    logger.log(provider, message);
+
+    expect(mockWriteStream.write).toHaveBeenCalledWith(
+      expect.stringMatching(/\[.*\] test-provider - test log\n/),
+    );
+  });
+
+  it('should end stream on destroy', () => {
+    logger.onModuleDestroy();
+    expect(mockWriteStream.end).toHaveBeenCalled();
+  });
+
+  it('should create logs directory if it does not exist', () => {
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+    const mkdirSpy = jest.spyOn(fs, 'mkdirSync');
+
+    new WeatherLogger();
+
+    expect(mkdirSpy).toHaveBeenCalledWith(path.resolve(process.cwd(), 'logs'), {
+      recursive: true,
+    });
+  });
+});

--- a/src/weather/infrastructure/logger/weather.logger.ts
+++ b/src/weather/infrastructure/logger/weather.logger.ts
@@ -1,0 +1,28 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WEATHER_LOG_FILE_PATH } from './weather-logger.config';
+
+@Injectable()
+export class WeatherLogger implements OnModuleDestroy {
+  private readonly stream: fs.WriteStream;
+
+  constructor() {
+    const logDir = path.dirname(WEATHER_LOG_FILE_PATH);
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+
+    this.stream = fs.createWriteStream(WEATHER_LOG_FILE_PATH, { flags: 'a' });
+  }
+
+  log(provider: string, message: string): void {
+    const timestamp = new Date().toISOString();
+    const fullMessage = `[${timestamp}] ${provider} - ${message}\n`;
+    this.stream.write(fullMessage);
+  }
+
+  onModuleDestroy() {
+    this.stream.end();
+  }
+}

--- a/src/weather/infrastructure/providers/openweathermap.provider.spec.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.spec.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { OpenWeatherMapProvider } from './openweathermap.provider';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { WeatherLogger } from '../logger/weather.logger';
+
+describe('OpenWeatherMapProvider', () => {
+  const config = {
+    baseUrl: 'http://api.openweathermap.org',
+    apiKey: 'test-key',
+  };
+  const city = 'Dnipro';
+
+  const mockResponse = {
+    data: {
+      main: {
+        temp: 30,
+        humidity: 40,
+      },
+      weather: [
+        {
+          description: 'Hot',
+        },
+      ],
+    },
+  } as AxiosResponse;
+
+  let httpService: HttpService;
+  let logger: WeatherLogger;
+  let provider: OpenWeatherMapProvider;
+
+  beforeEach(() => {
+    httpService = { get: jest.fn().mockReturnValue(of(mockResponse)) } as any;
+    logger = { log: jest.fn() } as any;
+    provider = new OpenWeatherMapProvider(httpService, config, logger);
+  });
+
+  it('should return mapped weather data', async () => {
+    const result = await provider.getWeather(city);
+    expect(result).toEqual({
+      temperature: 30,
+      humidity: 40,
+      description: 'Hot',
+    });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'openweathermap.org',
+      expect.stringMatching(/Response/),
+    );
+  });
+
+  it('should log and throw on error', async () => {
+    const error = new Error('API Error');
+    httpService.get = jest.fn().mockReturnValue(throwError(() => error)) as any;
+
+    await expect(provider.getWeather(city)).rejects.toThrow('API Error');
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'openweathermap.org',
+      expect.stringMatching(/Error/),
+    );
+  });
+});

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -4,16 +4,7 @@ import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
-
-interface OpenWeatherMapResponse {
-  main: {
-    temp: number;
-    humidity: number;
-  };
-  weather: {
-    description: string;
-  }[];
-}
+import { OpenWeatherMapResponse } from 'src/weather/infrastructure/providers/types/openweathermap-response.type';
 
 @Injectable()
 export class OpenWeatherMapProvider implements WeatherProvider {

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -5,6 +5,7 @@ import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import { OpenWeatherMapResponse } from 'src/weather/infrastructure/providers/types/openweathermap-response.type';
+import { buildOpenWeatherMapUrl } from '../helpers/weather-url.builder';
 
 @Injectable()
 export class OpenWeatherMapProvider implements WeatherProvider {
@@ -15,7 +16,11 @@ export class OpenWeatherMapProvider implements WeatherProvider {
   ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
-    const url = `${this.config.baseUrl}?q=${encodeURIComponent(city)}&appid=${this.config.apiKey}&units=metric`;
+    const url = buildOpenWeatherMapUrl(
+      this.config.baseUrl,
+      this.config.apiKey,
+      city,
+    );
 
     const response: AxiosResponse<OpenWeatherMapResponse> = await lastValueFrom(
       this.httpService.get<OpenWeatherMapResponse>(url),

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { WeatherProvider } from '../../domain/interfaces/weather-provider.interface';
+import { WeatherData } from 'src/weather/domain/types/weather-data.type';
+
+@Injectable()
+export class OpenWeatherMapProvider implements WeatherProvider {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+  async getWeather(city: string): Promise<WeatherData> {
+    return {
+      temperature: 20,
+      humidity: 50,
+      description: 'Sunny (from OpenWeatherMap stub)',
+    };
+  }
+}

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -1,8 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { WeatherProvider } from '../../domain/interfaces/weather-provider.interface';
 import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
-import { AppConfigService } from 'src/config/app-config.service';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
 
@@ -18,20 +17,14 @@ interface OpenWeatherMapResponse {
 
 @Injectable()
 export class OpenWeatherMapProvider implements WeatherProvider {
-  private readonly baseUrl: string;
-  private readonly apiKey: string;
-
   constructor(
     private readonly httpService: HttpService,
-    private readonly appConfigService: AppConfigService,
-  ) {
-    const { baseUrl, apiKey } = this.appConfigService.getOpenWeatherMapConfig();
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
+    @Inject('OPENWEATHER_API_CONFIG')
+    private readonly config: { baseUrl: string; apiKey: string },
+  ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
-    const url = `${this.baseUrl}?q=${encodeURIComponent(city)}&appid=${this.apiKey}&units=metric`;
+    const url = `${this.config.baseUrl}?q=${encodeURIComponent(city)}&appid=${this.config.apiKey}&units=metric`;
 
     const response: AxiosResponse<OpenWeatherMapResponse> = await lastValueFrom(
       this.httpService.get<OpenWeatherMapResponse>(url),

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -1,15 +1,48 @@
 import { Injectable } from '@nestjs/common';
 import { WeatherProvider } from '../../domain/interfaces/weather-provider.interface';
 import { WeatherData } from 'src/weather/domain/types/weather-data.type';
+import { HttpService } from '@nestjs/axios';
+import { AppConfigService } from 'src/config/app-config.service';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
+
+interface OpenWeatherMapResponse {
+  main: {
+    temp: number;
+    humidity: number;
+  };
+  weather: {
+    description: string;
+  }[];
+}
 
 @Injectable()
 export class OpenWeatherMapProvider implements WeatherProvider {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/require-await
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly appConfigService: AppConfigService,
+  ) {
+    const { baseUrl, apiKey } = this.appConfigService.getOpenWeatherMapConfig();
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
   async getWeather(city: string): Promise<WeatherData> {
+    const url = `${this.baseUrl}?q=${encodeURIComponent(city)}&appid=${this.apiKey}&units=metric`;
+
+    const response: AxiosResponse<OpenWeatherMapResponse> = await lastValueFrom(
+      this.httpService.get<OpenWeatherMapResponse>(url),
+    );
+
+    const data = response.data;
+
     return {
-      temperature: 20,
-      humidity: 50,
-      description: 'Sunny (from OpenWeatherMap stub)',
+      temperature: data.main.temp,
+      humidity: data.main.humidity,
+      description: data.weather[0].description,
     };
   }
 }

--- a/src/weather/infrastructure/providers/openweathermap.provider.ts
+++ b/src/weather/infrastructure/providers/openweathermap.provider.ts
@@ -4,15 +4,19 @@ import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
-import { OpenWeatherMapResponse } from 'src/weather/infrastructure/providers/types/openweathermap-response.type';
+import { OpenWeatherMapResponse } from './types/openweathermap-response.type';
 import { buildOpenWeatherMapUrl } from '../helpers/weather-url.builder';
+import { WeatherLogger } from '../logger/weather.logger';
 
 @Injectable()
 export class OpenWeatherMapProvider implements WeatherProvider {
+  private readonly PROVIDER_NAME = 'openweathermap.org';
+
   constructor(
     private readonly httpService: HttpService,
     @Inject('OPENWEATHER_API_CONFIG')
     private readonly config: { baseUrl: string; apiKey: string },
+    private readonly logger: WeatherLogger,
   ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
@@ -22,16 +26,31 @@ export class OpenWeatherMapProvider implements WeatherProvider {
       city,
     );
 
-    const response: AxiosResponse<OpenWeatherMapResponse> = await lastValueFrom(
-      this.httpService.get<OpenWeatherMapResponse>(url),
-    );
+    try {
+      const response: AxiosResponse<OpenWeatherMapResponse> =
+        await lastValueFrom(this.httpService.get<OpenWeatherMapResponse>(url));
 
-    const data = response.data;
+      // api error imitation
+      // throw new Error('Server unavailable');
 
-    return {
-      temperature: data.main.temp,
-      humidity: data.main.humidity,
-      description: data.weather[0].description,
-    };
+      this.logger.log(
+        this.PROVIDER_NAME,
+        `Response: ${JSON.stringify(response.data)}`,
+      );
+
+      const data = response.data;
+
+      return {
+        temperature: data.main.temp,
+        humidity: data.main.humidity,
+        description: data.weather[0].description,
+      };
+    } catch (error) {
+      this.logger.log(
+        this.PROVIDER_NAME,
+        `Error: ${JSON.stringify(error, Object.getOwnPropertyNames(error))}`,
+      );
+      throw error;
+    }
   }
 }

--- a/src/weather/infrastructure/providers/types/openweathermap-response.type.ts
+++ b/src/weather/infrastructure/providers/types/openweathermap-response.type.ts
@@ -1,0 +1,9 @@
+export type OpenWeatherMapResponse = {
+  main: {
+    temp: number;
+    humidity: number;
+  };
+  weather: {
+    description: string;
+  }[];
+};

--- a/src/weather/infrastructure/providers/types/weatherapi-response.type.ts
+++ b/src/weather/infrastructure/providers/types/weatherapi-response.type.ts
@@ -1,4 +1,4 @@
-export interface WeatherApiResponse {
+export type WeatherApiResponse = {
   location: {
     name: string;
   };
@@ -9,4 +9,4 @@ export interface WeatherApiResponse {
       text: string;
     };
   };
-}
+};

--- a/src/weather/infrastructure/providers/weather-api.provider.spec.ts
+++ b/src/weather/infrastructure/providers/weather-api.provider.spec.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { WeatherApiProvider } from './weatherapi.provider';
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import { WeatherLogger } from '../logger/weather.logger';
+
+describe('WeatherApiProvider', () => {
+  const config = { baseUrl: 'http://api.weatherapi.com', apiKey: 'test-key' };
+  const city = 'Odesa';
+
+  const mockResponse = {
+    data: {
+      current: {
+        temp_c: 22,
+        humidity: 50,
+        condition: {
+          text: 'Clear',
+        },
+      },
+    },
+  } as AxiosResponse;
+
+  let httpService: HttpService;
+  let logger: WeatherLogger;
+  let provider: WeatherApiProvider;
+
+  beforeEach(() => {
+    httpService = { get: jest.fn().mockReturnValue(of(mockResponse)) } as any;
+    logger = { log: jest.fn() } as any;
+    provider = new WeatherApiProvider(httpService, config, logger);
+  });
+
+  it('should return mapped weather data', async () => {
+    const result = await provider.getWeather(city);
+    expect(result).toEqual({
+      temperature: 22,
+      humidity: 50,
+      description: 'Clear',
+    });
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'weatherapi.com',
+      expect.stringMatching(/Response/),
+    );
+  });
+
+  it('should log and throw on error', async () => {
+    httpService.get = jest.fn().mockReturnValueOnce({
+      toPromise: () => Promise.reject(new Error('API Error')),
+    }) as any;
+
+    const erroringProvider = new WeatherApiProvider(
+      httpService,
+      config,
+      logger,
+    );
+    await expect(erroringProvider.getWeather(city)).rejects.toThrow();
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'weatherapi.com',
+      expect.stringMatching(/Error/),
+    );
+  });
+});

--- a/src/weather/infrastructure/providers/weatherapi.provider.ts
+++ b/src/weather/infrastructure/providers/weatherapi.provider.ts
@@ -5,6 +5,7 @@ import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import { WeatherApiResponse } from 'src/weather/infrastructure/providers/types/weatherapi-response.type';
+import { buildWeatherApiUrl } from '../helpers/weather-url.builder';
 
 @Injectable()
 export class WeatherApiProvider implements WeatherProvider {
@@ -15,7 +16,11 @@ export class WeatherApiProvider implements WeatherProvider {
   ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
-    const url = `${this.config.baseUrl}?key=${this.config.apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
+    const url = buildWeatherApiUrl(
+      this.config.baseUrl,
+      this.config.apiKey,
+      city,
+    );
 
     const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
       this.httpService.get<WeatherApiResponse>(url),

--- a/src/weather/infrastructure/providers/weatherapi.provider.ts
+++ b/src/weather/infrastructure/providers/weatherapi.provider.ts
@@ -4,7 +4,7 @@ import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
-import { WeatherApiResponse } from '../../../common/interfaces/weatherapi-response.interface';
+import { WeatherApiResponse } from 'src/weather/infrastructure/providers/types/weatherapi-response.type';
 
 @Injectable()
 export class WeatherApiProvider implements WeatherProvider {

--- a/src/weather/infrastructure/providers/weatherapi.provider.ts
+++ b/src/weather/infrastructure/providers/weatherapi.provider.ts
@@ -1,28 +1,21 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { WeatherProvider } from '../../domain/interfaces/weather-provider.interface';
 import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
-import { AppConfigService } from 'src/config/app-config.service';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import { WeatherApiResponse } from '../../../common/interfaces/weatherapi-response.interface';
 
 @Injectable()
 export class WeatherApiProvider implements WeatherProvider {
-  private readonly baseUrl: string;
-  private readonly apiKey: string;
-
   constructor(
     private readonly httpService: HttpService,
-    private readonly appConfigService: AppConfigService,
-  ) {
-    const { baseUrl, apiKey } = this.appConfigService.getWeatherApiConfig();
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
+    @Inject('WEATHER_API_CONFIG')
+    private readonly config: { baseUrl: string; apiKey: string },
+  ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
-    const url = `${this.baseUrl}?key=${this.apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
+    const url = `${this.config.baseUrl}?key=${this.config.apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
 
     const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
       this.httpService.get<WeatherApiResponse>(url),

--- a/src/weather/infrastructure/providers/weatherapi.provider.ts
+++ b/src/weather/infrastructure/providers/weatherapi.provider.ts
@@ -4,15 +4,19 @@ import { WeatherData } from 'src/weather/domain/types/weather-data.type';
 import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { lastValueFrom } from 'rxjs';
-import { WeatherApiResponse } from 'src/weather/infrastructure/providers/types/weatherapi-response.type';
+import { WeatherApiResponse } from './types/weatherapi-response.type';
 import { buildWeatherApiUrl } from '../helpers/weather-url.builder';
+import { WeatherLogger } from '../logger/weather.logger';
 
 @Injectable()
 export class WeatherApiProvider implements WeatherProvider {
+  private readonly PROVIDER_NAME = 'weatherapi.com';
+
   constructor(
     private readonly httpService: HttpService,
     @Inject('WEATHER_API_CONFIG')
     private readonly config: { baseUrl: string; apiKey: string },
+    private readonly logger: WeatherLogger,
   ) {}
 
   async getWeather(city: string): Promise<WeatherData> {
@@ -22,16 +26,29 @@ export class WeatherApiProvider implements WeatherProvider {
       city,
     );
 
-    const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
-      this.httpService.get<WeatherApiResponse>(url),
-    );
+    try {
+      const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
+        this.httpService.get<WeatherApiResponse>(url),
+      );
 
-    const data = response.data;
+      this.logger.log(
+        this.PROVIDER_NAME,
+        `Response: ${JSON.stringify(response.data)}`,
+      );
 
-    return {
-      temperature: data.current.temp_c,
-      humidity: data.current.humidity,
-      description: data.current.condition.text,
-    };
+      const data = response.data;
+
+      return {
+        temperature: data.current.temp_c,
+        humidity: data.current.humidity,
+        description: data.current.condition.text,
+      };
+    } catch (error) {
+      this.logger.log(
+        this.PROVIDER_NAME,
+        `Error: ${JSON.stringify(error, Object.getOwnPropertyNames(error))}`,
+      );
+      throw error;
+    }
   }
 }

--- a/src/weather/infrastructure/providers/weatherapi.provider.ts
+++ b/src/weather/infrastructure/providers/weatherapi.provider.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { WeatherProvider } from '../../domain/interfaces/weather-provider.interface';
+import { WeatherData } from 'src/weather/domain/types/weather-data.type';
+import { HttpService } from '@nestjs/axios';
+import { AppConfigService } from 'src/config/app-config.service';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
+import { WeatherApiResponse } from '../../../common/interfaces/weatherapi-response.interface';
+
+@Injectable()
+export class WeatherApiProvider implements WeatherProvider {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly appConfigService: AppConfigService,
+  ) {
+    const { baseUrl, apiKey } = this.appConfigService.getWeatherApiConfig();
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+  }
+
+  async getWeather(city: string): Promise<WeatherData> {
+    const url = `${this.baseUrl}?key=${this.apiKey}&q=${encodeURIComponent(city)}&aqi=no`;
+
+    const response: AxiosResponse<WeatherApiResponse> = await lastValueFrom(
+      this.httpService.get<WeatherApiResponse>(url),
+    );
+
+    const data = response.data;
+
+    return {
+      temperature: data.current.temp_c,
+      humidity: data.current.humidity,
+      description: data.current.condition.text,
+    };
+  }
+}

--- a/src/weather/weather.module.ts
+++ b/src/weather/weather.module.ts
@@ -19,6 +19,31 @@ import { OpenWeatherMapProvider } from './infrastructure/providers/openweatherma
     WeatherApiProvider,
     OpenWeatherMapProvider,
     {
+      provide: 'WEATHER_API_CONFIG',
+      useFactory: () => {
+        const baseUrl = process.env.WEATHER_API_BASE_URL;
+        const apiKey = process.env.WEATHER_API_KEY;
+        if (!baseUrl || !apiKey) {
+          throw new Error('Missing WEATHER_API_BASE_URL or WEATHER_API_KEY');
+        }
+        return { baseUrl, apiKey };
+      },
+    },
+
+    {
+      provide: 'OPENWEATHER_API_CONFIG',
+      useFactory: () => {
+        const baseUrl = process.env.OPENWEATHER_API_BASE_URL;
+        const apiKey = process.env.OPENWEATHER_API_KEY;
+        if (!baseUrl || !apiKey) {
+          throw new Error(
+            'Missing OPENWEATHER_API_BASE_URL or OPENWEATHER_API_KEY',
+          );
+        }
+        return { baseUrl, apiKey };
+      },
+    },
+    {
       provide: 'WEATHER_PROVIDERS',
       useFactory: (
         openWeather: OpenWeatherMapProvider,

--- a/src/weather/weather.module.ts
+++ b/src/weather/weather.module.ts
@@ -8,6 +8,7 @@ import { WeatherClient } from './application/weather-client';
 import { WeatherProvider } from './domain/interfaces/weather-provider.interface';
 import { WeatherApiProvider } from './infrastructure/providers/weatherapi.provider';
 import { OpenWeatherMapProvider } from './infrastructure/providers/openweathermap.provider';
+import { WeatherProviderConfig } from './domain/types/weather-provider-config.type';
 
 @Module({
   imports: [HttpModule, ConfigModule],
@@ -15,34 +16,25 @@ import { OpenWeatherMapProvider } from './infrastructure/providers/openweatherma
   providers: [
     WeatherService,
     AppConfigService,
-    WeatherClient,
     WeatherApiProvider,
     OpenWeatherMapProvider,
+
+    // Weather providers configs
     {
       provide: 'WEATHER_API_CONFIG',
-      useFactory: () => {
-        const baseUrl = process.env.WEATHER_API_BASE_URL;
-        const apiKey = process.env.WEATHER_API_KEY;
-        if (!baseUrl || !apiKey) {
-          throw new Error('Missing WEATHER_API_BASE_URL or WEATHER_API_KEY');
-        }
-        return { baseUrl, apiKey };
-      },
+      useFactory: (config: AppConfigService): WeatherProviderConfig =>
+        config.getWeatherApiConfig(),
+      inject: [AppConfigService],
     },
 
     {
       provide: 'OPENWEATHER_API_CONFIG',
-      useFactory: () => {
-        const baseUrl = process.env.OPENWEATHER_API_BASE_URL;
-        const apiKey = process.env.OPENWEATHER_API_KEY;
-        if (!baseUrl || !apiKey) {
-          throw new Error(
-            'Missing OPENWEATHER_API_BASE_URL or OPENWEATHER_API_KEY',
-          );
-        }
-        return { baseUrl, apiKey };
-      },
+      useFactory: (config: AppConfigService): WeatherProviderConfig =>
+        config.getOpenWeatherMapConfig(),
+      inject: [AppConfigService],
     },
+
+    // WEATHER_PROVIDERS
     {
       provide: 'WEATHER_PROVIDERS',
       useFactory: (
@@ -51,6 +43,8 @@ import { OpenWeatherMapProvider } from './infrastructure/providers/openweatherma
       ) => [openWeather, weatherApi],
       inject: [OpenWeatherMapProvider, WeatherApiProvider],
     },
+
+    // WeatherClient
     {
       provide: WeatherClient,
       useFactory: (providers: WeatherProvider[]) =>

--- a/src/weather/weather.module.ts
+++ b/src/weather/weather.module.ts
@@ -4,11 +4,35 @@ import { ConfigModule } from '@nestjs/config';
 import { WeatherController } from './interfaces/controllers/weather.controller';
 import { WeatherService } from './application/weather.service';
 import { AppConfigService } from 'src/config/app-config.service';
+import { WeatherClient } from './application/weather-client';
+import { WeatherProvider } from './domain/interfaces/weather-provider.interface';
+import { WeatherApiProvider } from './infrastructure/providers/weatherapi.provider';
+import { OpenWeatherMapProvider } from './infrastructure/providers/openweathermap.provider';
 
 @Module({
   imports: [HttpModule, ConfigModule],
   controllers: [WeatherController],
-  providers: [WeatherService, AppConfigService],
+  providers: [
+    WeatherService,
+    AppConfigService,
+    WeatherClient,
+    WeatherApiProvider,
+    OpenWeatherMapProvider,
+    {
+      provide: 'WEATHER_PROVIDERS',
+      useFactory: (
+        openWeather: OpenWeatherMapProvider,
+        weatherApi: WeatherApiProvider,
+      ) => [openWeather, weatherApi],
+      inject: [OpenWeatherMapProvider, WeatherApiProvider],
+    },
+    {
+      provide: WeatherClient,
+      useFactory: (providers: WeatherProvider[]) =>
+        new WeatherClient(providers),
+      inject: ['WEATHER_PROVIDERS'],
+    },
+  ],
   exports: [WeatherService],
 })
 export class WeatherModule {}

--- a/src/weather/weather.module.ts
+++ b/src/weather/weather.module.ts
@@ -9,6 +9,7 @@ import { WeatherProvider } from './domain/interfaces/weather-provider.interface'
 import { WeatherApiProvider } from './infrastructure/providers/weatherapi.provider';
 import { OpenWeatherMapProvider } from './infrastructure/providers/openweathermap.provider';
 import { WeatherProviderConfig } from './domain/types/weather-provider-config.type';
+import { WeatherLogger } from './infrastructure/logger/weather.logger';
 
 @Module({
   imports: [HttpModule, ConfigModule],
@@ -18,6 +19,7 @@ import { WeatherProviderConfig } from './domain/types/weather-provider-config.ty
     AppConfigService,
     WeatherApiProvider,
     OpenWeatherMapProvider,
+    WeatherLogger,
 
     // Weather providers configs
     {


### PR DESCRIPTION
Added a second weather provider (OpenWeatherMap) alongside the existing one to support failover. Added a common WeatherProvider interface to enable dependency inversion and simplify provider extension. Created WeatherClient to encapsulate the logic of trying providers in sequence using a WeatherProviderChain.

CoR pattern: the chain iterates over providers in order until one succeeds; if all fail, it throws. This is not a classical Chain of Responsibility pattern with linked handlers and a setNext(), but rather a simplified, stateless variant based on iteration, which is more practical for HTTP request flows and avoids state-related side effects in a shared service. This approach ensure providers don’t know about each other and to follow the Open/Closed Principle, as new providers can be added without modifying existing ones.

Also added WeatherLogger, a class that logs both successful responses and errors from each provider to a file.